### PR TITLE
Update multidict and yarl versions so it installs on Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ lockfile==0.12.2
 markupsafe==1.1.1
 mccabe==0.6.1
 msgpack==0.6.2
-multidict==5.1.0
+multidict==6.1.0
 pep517==0.8.2
 progress==1.5
 pycparser==2.20
@@ -46,4 +46,4 @@ webencodings==0.5.1
 websockets==8.1
 werkzeug==1.0.1
 wrapt==1.12.1
-yarl==1.6.3
+yarl==1.18.3


### PR DESCRIPTION
Why do we make computers so difficult.

References:
* https://github.com/aio-libs/yarl/issues/706
* https://github.com/aio-libs/multidict/issues/862